### PR TITLE
add global binary support for hltb in your shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,17 @@
 
 A javascript (node + browser) module for pulling time data from [HLTB](http://howlongtobeat.com).
 
+## Installation
+
+```
+npm install hltb  # -g if you want the command line tools
+```
+
 ## Usage
 
 To use the API within your code you can use `#search` to return all the games that match the provided string, with access to each time.
 
-```
+```js
 import HLTB from '../lib/hltb';
 
 HLTB.search({{game title}}, (err, games) => {
@@ -31,8 +37,9 @@ Each time returned is in minutes.
 A CLI is also available for quickly searching users data to use in your shell.
 
 ```bash
+npm install -g hltb
 # return all games belonging to {{username}} in JSON format
-npm run cli {{game title}}
+hltb {{game title}}
 ```
 
 # License

--- a/package.json
+++ b/package.json
@@ -1,8 +1,11 @@
 {
   "name": "hltb",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A module for pulling time data from HLTB",
   "main": "lib/hltb.js",
+  "bin": {
+    "hltb": "./bin/cli.js"
+  },
   "scripts": {
     "prepublish": "gulp es2015",
     "cli": "node bin/cli.js",

--- a/src/bin/cli.js
+++ b/src/bin/cli.js
@@ -1,11 +1,13 @@
+#!/usr/bin/env node
+
 import minimist from 'minimist';
 import HLTB from '../lib/hltb';
 
 const argv = minimist(process.argv.slice(2));
 const gameSearch = argv.game || argv._[0];
 
-if (gameSearch === null) {
-  console.error('Please provide a game to search');
+if (!gameSearch) {
+  console.error('Provide a game to search');
   process.exit(1);
 }
 


### PR DESCRIPTION
This will allow `npm install hltb -g` to create a binary `hltb` that can be used anywhere in your shell rather than requiring you to build the whole package yourself.
